### PR TITLE
skip tomos that failed evaluation

### DIFF
--- a/geollama/evaluate.py
+++ b/geollama/evaluate.py
@@ -301,15 +301,15 @@ def _eval_generator(filelist_in: list, params: objects.Config):
             except Exception as e:
                 logging.warning(f"Could not process {Path(tomo).stem} due to {e}")
                 null_result = objects.Result(
-                    yz_stats=np.full((1,5), np.nan),
-                    xz_stats=np.full((1,5), np.nan),
+                    yz_stats=np.full((1, 5), np.nan),
+                    xz_stats=np.full((1, 5), np.nan),
                     yz_mean=np.full((5,), np.nan),
                     xz_mean=np.full((5,), np.nan),
                     yz_sem=np.full((5,), np.nan),
                     xz_sem=np.full((5,), np.nan),
                     surfaces=None,
                     binning_factor=None,
-                    adaptive_triggered=False
+                    adaptive_triggered=False,
                 )
                 yield null_result
 

--- a/geollama/evaluate.py
+++ b/geollama/evaluate.py
@@ -300,6 +300,18 @@ def _eval_generator(filelist_in: list, params: objects.Config):
                 yield eval_result
             except Exception as e:
                 logging.warning(f"Could not process {Path(tomo).stem} due to {e}")
+                null_result = objects.Result(
+                    yz_stats=np.full((1,5), np.nan),
+                    xz_stats=np.full((1,5), np.nan),
+                    yz_mean=np.full((5,), np.nan),
+                    xz_mean=np.full((5,), np.nan),
+                    yz_sem=np.full((5,), np.nan),
+                    xz_sem=np.full((5,), np.nan),
+                    surfaces=None,
+                    binning_factor=None,
+                    adaptive_triggered=False
+                )
+                yield null_result
 
 
 def eval_batch(

--- a/geollama/evaluate.py
+++ b/geollama/evaluate.py
@@ -295,8 +295,11 @@ def _eval_generator(filelist_in: list, params: objects.Config):
     with prog_bar as p:
         clear_tasks(p)
         for tomo in p.track(filelist_in, total=len(filelist_in)):
-            eval_result = eval_single(fname=tomo, params=params)
-            yield eval_result
+            try:
+                eval_result = eval_single(fname=tomo, params=params)
+                yield eval_result
+            except Exception as e:
+                logging.warning(f"Could not process {Path(tomo).stem} due to {e}")
 
 
 def eval_batch(

--- a/geollama/report.py
+++ b/geollama/report.py
@@ -102,7 +102,7 @@ def generate_report(report_path: Path, star_path: Path, to_html: bool = False):
             "starfile_path": str(star_path),
         },
         kernel="python3",
-        allow_errors=True
+        allow_errors=True,
     )
 
     Path(f"{report_path.parent}/{report_path.stem}_tmp.ipynb").unlink()

--- a/geollama/report.py
+++ b/geollama/report.py
@@ -102,6 +102,7 @@ def generate_report(report_path: Path, star_path: Path, to_html: bool = False):
             "starfile_path": str(star_path),
         },
         kernel="python3",
+        allow_errors=True
     )
 
     Path(f"{report_path.parent}/{report_path.stem}_tmp.ipynb").unlink()


### PR DESCRIPTION
When running Geollama on a whole folder of tomograms, Geollama raises an error and exits when it finds the first tomogram that fails. I added a try-except loop to warn the user if one of the tomograms fails and continues with the rest of the folder.